### PR TITLE
CN-84 Add the pack code as a template option for export files

### DIFF
--- a/acceptance_tests/features/steps/export_file.py
+++ b/acceptance_tests/features/steps/export_file.py
@@ -18,6 +18,7 @@ from config import Config
 @step("an export file is created with correct rows")
 def check_export_file(context):
     template = context.template
+    pack_code = context.pack_code
     emitted_uacs = context.emitted_uacs if hasattr(context, 'emitted_uacs') else None
     fulfilment_personalisation = context.fulfilment_personalisation if hasattr(context,
                                                                                'fulfilment_personalisation') else None
@@ -38,7 +39,8 @@ def check_export_file(context):
     expected_export_file_rows = generate_expected_export_file_rows(template,
                                                                    context.emitted_cases,
                                                                    emitted_uacs, uacs_from_actual_export_file,
-                                                                   fulfilment_personalisation)
+                                                                   fulfilment_personalisation,
+                                                                   pack_code)
 
     check_export_file_matches_expected(actual_export_file_rows, expected_export_file_rows)
 
@@ -94,7 +96,7 @@ def _get_unhashed_uacs_from_actual_export_file(actual_export_file_rows, template
 
 
 def generate_expected_export_file_rows(template: List, cases: List, uac_update_events: List, expected_uacs: List,
-                                       fulfilment_personalisation: Dict):
+                                       fulfilment_personalisation: Dict, pack_code: str):
     hashed_uac_to_uac = {
         hashlib.sha256(uac.encode('utf-8')).hexdigest(): uac
         for uac in expected_uacs
@@ -114,6 +116,8 @@ def generate_expected_export_file_rows(template: List, cases: List, uac_update_e
                 export_row_components.append(fulfilment_personalisation[field.split('.')[1]])
             elif field.startswith('__caseref__'):
                 export_row_components.append(case['caseRef'])
+            elif field.startswith('__pack_code__'):
+                export_row_components.append(pack_code)
             else:
 
                 export_row_components.append(

--- a/resources/template_files/export_file_templates.json
+++ b/resources/template_files/export_file_templates.json
@@ -1,17 +1,17 @@
 [
   {
     "templateName": "ICL1",
-    "template": ["__uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
+    "template": ["__uac__", "__caseref__", "__pack_code__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
     "questionnaireType": "01"
   },
   {
     "templateName": "1RL1",
-    "template": ["__uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
+    "template": ["__uac__", "__caseref__", "__pack_code__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
     "questionnaireType": "02"
   },
     {
     "templateName": "1RL2",
-    "template": ["__uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
+    "template": ["__uac__", "__caseref__", "__pack_code__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
       "questionnaireType": "03"
   },
       {


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Include pack code in the export file service. 
* [ ] [Context Index](github.com/ONSdigital/census-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
<!--- What code changes has been made -->
Modified to include pack_code in the template and include the  pack_code to the existing test scenario
<!--- Has there been any refactoring -->
No refactoring
<!--- What tests have been written -->
yes part of the acceptance testing

# How to test?
<!--- Describe in detail how you tested your changes. -->
make test
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
No automated test
# Links
<!--- Add any links to issues (trello, github issues) -->
https://officefornationalstatistics.atlassian.net/browse/CN-84
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):