### PR TITLE
CN-85 Add template options for a welsh uac and welsh qid for export

### DIFF
--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -115,8 +115,11 @@ def _setup_templates(context):
     context.export_file_templates = {template['templateName']: template for template in export_file_templates}
     context.export_file_packcodes = {}
     for _, template in context.export_file_templates.items():
-        context.export_file_packcodes[template['templateName']] = {"pack_code": template['templateName'],
-                                                                   "questionnaire_type": template['questionnaireType']}
+        context.export_file_packcodes[template['templateName']] = {
+            "pack_code": template['templateName'],
+            "questionnaire_type": template['questionnaireType'],
+            "welsh_questionnaire_type": template.get('welshQuestionnaireType')
+        }
 
     sms_templates_path = TEMPLATE_FILES_PATH.joinpath("sms_templates.json")
     sms_templates = json.loads(sms_templates_path.read_text())

--- a/acceptance_tests/features/export_file.feature
+++ b/acceptance_tests/features/export_file.feature
@@ -21,7 +21,7 @@ Feature: Export files can be created with the correct data
       | sample_input_england_census_spec.csv | 1RL2     |
       | sample_input_england_census_spec.csv | 1RL2-W   |
 
-  Scenario Outline: A case is loaded, action rule triggered and export file created with a template with no UAC
+  Scenario Outline: A case is loaded, action rule triggered and export file created with a template with no UAC in it
     Given sample file "<sample file>" is loaded successfully
     And an export file template has been created with template "<template>"
     When an export file action rule has been created for packcode "<template>"

--- a/acceptance_tests/features/export_file.feature
+++ b/acceptance_tests/features/export_file.feature
@@ -21,7 +21,7 @@ Feature: Export files can be created with the correct data
       | sample_input_england_census_spec.csv | 1RL2     |
       | sample_input_england_census_spec.csv | 1RL2-W   |
 
-  Scenario Outline: A case is loaded, action rule triggered and export file created with a template with no UAC in it
+  Scenario Outline: A case is loaded, action rule triggered and export file created with a template with no UAC
     Given sample file "<sample file>" is loaded successfully
     And an export file template has been created with template "<template>"
     When an export file action rule has been created for packcode "<template>"

--- a/acceptance_tests/features/export_file.feature
+++ b/acceptance_tests/features/export_file.feature
@@ -11,12 +11,15 @@ Feature: Export files can be created with the correct data
     Examples:
       | sample file                          | template |
       | sample_input_england_census_spec.csv | ICL1     |
+      | sample_input_england_census_spec.csv | ICL1-W   |
 
     @regression
     Examples:
       | sample file                          | template |
       | sample_input_england_census_spec.csv | 1RL1     |
+      | sample_input_england_census_spec.csv | 1RL1-W   |
       | sample_input_england_census_spec.csv | 1RL2     |
+      | sample_input_england_census_spec.csv | 1RL2-W   |
 
   Scenario Outline: A case is loaded, action rule triggered and export file created with a template with no UAC
     Given sample file "<sample file>" is loaded successfully
@@ -28,3 +31,4 @@ Feature: Export files can be created with the correct data
     Examples:
       | sample file                          | template |
       | sample_input_england_census_spec.csv | PC       |
+      | sample_input_england_census_spec.csv | PC-W     |

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -56,6 +56,12 @@ def check_uac_update_msgs_emitted_with_qid_active(context, active):
     for emitted_uac in context.emitted_uacs:
         test_helper.assertEqual(emitted_uac['qid'][:2], context.expected_questionnaire_type)
 
+    # Validate Welsh questionnaire type if present in context
+    if hasattr(context, 'expected_welsh_questionnaire_type') and context.expected_welsh_questionnaire_type:
+        for emitted_uac in context.emitted_uacs:
+            if 'welsh_qid' in emitted_uac and emitted_uac['welsh_qid']:
+                test_helper.assertEqual(emitted_uac['welsh_qid'][:2], context.expected_welsh_questionnaire_type)
+
 
 @step('the correct number of UAC_UPDATE messages are emitted with active set to {active:boolean}')
 def check_uac_updated_messages_by_number_with_qid_active(context, active):

--- a/acceptance_tests/features/steps/export_file.py
+++ b/acceptance_tests/features/steps/export_file.py
@@ -27,6 +27,13 @@ def check_export_file(context):
                             'Export file template expects UACs or QIDs but no corresponding emitted_uacs found in '
                             f'the scenario context, emitted_uacs {emitted_uacs}')
 
+    welsh_error_message = (
+        'Export file template expects welsh UACs or QIDs but no corresponding welsh emitted_uacs found in '
+        f'the scenario context, emitted_uacs {emitted_uacs}'
+    )
+    test_helper.assertFalse(('__welsh_uac__' in template or '__welsh_qid__' in template) and not emitted_uacs,
+                            welsh_error_message)
+
     supplier = _get_context_export_supplier_or_default(context)
 
     actual_export_file_rows = get_export_file_rows(context.test_start_utc_datetime, context.pack_code,
@@ -36,13 +43,23 @@ def check_export_file(context):
         actual_export_file_rows, template
     ) if '__uac__' in template else []
 
-    expected_export_file_rows = generate_expected_export_file_rows(template,
-                                                                   context.emitted_cases,
-                                                                   emitted_uacs, uacs_from_actual_export_file,
-                                                                   fulfilment_personalisation,
-                                                                   pack_code)
+    welsh_uacs_from_actual_export_file = _get_unhashed_welsh_uacs_from_actual_export_file(
+        actual_export_file_rows, template
+    ) if '__welsh_uac__' in template else []
 
-    check_export_file_matches_expected(actual_export_file_rows, expected_export_file_rows)
+    if '__uac__' in template:
+        expected_export_file_rows = generate_expected_export_file_rows(
+            template, context.emitted_cases, emitted_uacs, uacs_from_actual_export_file,
+            fulfilment_personalisation, pack_code
+        )
+        check_export_file_matches_expected(actual_export_file_rows, expected_export_file_rows)
+
+    if '__welsh_uac__' in template:
+        expected_welsh_export_file_rows = generate_expected_export_file_rows(
+            template, context.emitted_cases, emitted_uacs, welsh_uacs_from_actual_export_file,
+            fulfilment_personalisation, pack_code
+        )
+        check_export_file_matches_expected(actual_export_file_rows, expected_welsh_export_file_rows)
 
 
 @step('an export file template has been created with template "{template_name}"')
@@ -51,6 +68,8 @@ def create_export_file_template(context, template_name):
     context.pack_code = context.export_file_packcodes[template_name]['pack_code']
     context.expected_questionnaire_type = context.export_file_packcodes[template_name][
         'questionnaire_type']
+    context.expected_welsh_questionnaire_type = context.export_file_packcodes[template_name][
+        'welsh_questionnaire_type']
 
 
 @step('an export file template has been created for the internal reprographics supplier with template {template:array}')
@@ -95,6 +114,12 @@ def _get_unhashed_uacs_from_actual_export_file(actual_export_file_rows, template
     return tuple(export_file_row["__uac__"] for export_file_row in export_file_reader)
 
 
+def _get_unhashed_welsh_uacs_from_actual_export_file(actual_export_file_rows, template):
+    export_file_reader = csv.DictReader(actual_export_file_rows, fieldnames=template, delimiter=',')
+    next(export_file_reader, None)  # Exclude header row
+    return tuple(export_file_row["__welsh_uac__"] for export_file_row in export_file_reader)
+
+
 def generate_expected_export_file_rows(template: List, cases: List, uac_update_events: List, expected_uacs: List,
                                        fulfilment_personalisation: Dict, pack_code: str):
     hashed_uac_to_uac = {
@@ -110,6 +135,12 @@ def generate_expected_export_file_rows(template: List, cases: List, uac_update_e
                 hashed_uac = get_uac_hash_by_case_id(uac_update_events, case['caseId'])
                 export_row_components.append(hashed_uac_to_uac[hashed_uac])
             elif field == '__qid__':
+                qid = get_qid_by_case_id(uac_update_events, case['caseId'])
+                export_row_components.append(qid)
+            elif field == '__welsh_uac__':
+                hashed_uac = get_uac_hash_by_case_id(uac_update_events, case['caseId'])
+                export_row_components.append(hashed_uac_to_uac[hashed_uac])
+            elif field == '__welsh_qid__':
                 qid = get_qid_by_case_id(uac_update_events, case['caseId'])
                 export_row_components.append(qid)
             elif field.startswith('__request__'):

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -85,3 +85,8 @@ def check_uac_message_matches_sms_uac(context):
                             f"context.emitted_uacs: {context.emitted_uacs} "
                             f"context.fulfilment_response_json {context.fulfilment_response_json}")
     test_helper.assertEqual(context.emitted_uacs[0]['qid'][:2], context.expected_questionnaire_type)
+
+    # Validate Welsh questionnaire type if present in context
+    if hasattr(context, 'expected_welsh_questionnaire_type') and context.expected_welsh_questionnaire_type:
+        if 'welsh_qid' in context.emitted_uacs[0] and context.emitted_uacs[0]['welsh_qid']:
+            test_helper.assertEqual(context.emitted_uacs[0]['welsh_qid'][:2], context.expected_welsh_questionnaire_type)

--- a/resources/template_files/export_file_templates.json
+++ b/resources/template_files/export_file_templates.json
@@ -17,7 +17,7 @@
     {
     "templateName": "PC",
     "template": ["ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
-      "questionnaireType": null
+    "questionnaireType": null
   },
     {
     "templateName": "ICL1-W",
@@ -35,12 +35,12 @@
     "templateName": "1RL2-W",
     "template": ["__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
     "questionnaireType": "03",
-      "welshQuestionnaireType": "03"
+    "welshQuestionnaireType": "03"
   },
     {
     "templateName": "PC-W",
     "template": ["ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
     "questionnaireType": null,
-      "welshQuestionnaireType": null
+    "welshQuestionnaireType": null
   }
 ]

--- a/resources/template_files/export_file_templates.json
+++ b/resources/template_files/export_file_templates.json
@@ -4,7 +4,7 @@
     "template": ["__uac__", "__caseref__", "__pack_code__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
     "questionnaireType": "01"
   },
-  {
+    {
     "templateName": "1RL1",
     "template": ["__uac__", "__caseref__", "__pack_code__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
     "questionnaireType": "02"
@@ -14,9 +14,33 @@
     "template": ["__uac__", "__caseref__", "__pack_code__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
       "questionnaireType": "03"
   },
-      {
+    {
     "templateName": "PC",
     "template": ["ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
       "questionnaireType": null
+  },
+    {
+    "templateName": "ICL1-W",
+    "template": ["__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
+    "questionnaireType": "01",
+    "welshQuestionnaireType": "01"
+  },
+   {
+    "templateName": "1RL1-W",
+    "template": ["__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
+    "questionnaireType": "02",
+    "welshQuestionnaireType": "02"
+  },
+    {
+    "templateName": "1RL2-W",
+    "template": ["__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
+    "questionnaireType": "03",
+      "welshQuestionnaireType": "03"
+  },
+    {
+    "templateName": "PC-W",
+    "template": ["ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
+    "questionnaireType": null,
+      "welshQuestionnaireType": null
   }
 ]

--- a/resources/template_files/export_file_templates.json
+++ b/resources/template_files/export_file_templates.json
@@ -21,19 +21,19 @@
   },
     {
     "templateName": "ICL1-W",
-    "template": ["__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
+    "template": ["__uac__", "__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
     "questionnaireType": "02",
     "welshQuestionnaireType": "03"
   },
    {
     "templateName": "1RL1-W",
-    "template": ["__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
+    "template": ["__uac__", "__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
     "questionnaireType": "02",
     "welshQuestionnaireType": "03"
   },
     {
     "templateName": "1RL2-W",
-    "template": ["__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
+    "template": ["__uac__", "__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
     "questionnaireType": "02",
     "welshQuestionnaireType": "03"
   },

--- a/resources/template_files/export_file_templates.json
+++ b/resources/template_files/export_file_templates.json
@@ -22,19 +22,19 @@
     {
     "templateName": "ICL1-W",
     "template": ["__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
-    "questionnaireType": "01",
-    "welshQuestionnaireType": "01"
+    "questionnaireType": "02",
+    "welshQuestionnaireType": "03"
   },
    {
     "templateName": "1RL1-W",
     "template": ["__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
     "questionnaireType": "02",
-    "welshQuestionnaireType": "02"
+    "welshQuestionnaireType": "03"
   },
     {
     "templateName": "1RL2-W",
     "template": ["__welsh_uac__", "__caseref__", "ADDRESS_LINE1", "ADDRESS_LINE2", "ADDRESS_LINE3", "TOWN_NAME", "POSTCODE"],
-    "questionnaireType": "03",
+    "questionnaireType": "02",
     "welshQuestionnaireType": "03"
   },
     {


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](github.com/ONSdigital/census-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

For bilingual Welsh print products where separate pieces of paper are used (e.g. print questionnaires), we need to be able to include a second Welsh UAC/QID pair.

Add template options for a welsh uac and welsh qid for export files

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Added new acceptance tests for welsh uac and qid support with test data templates for welsh uac and qid for export files 

No refactoring

New acceptance tests added.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
See README.md documentation. Build and unit test with 'make test'.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://officefornationalstatistics.atlassian.net/browse/CN-85

# Screenshots (if appropriate):
<img width="3430" height="724" alt="image" src="https://github.com/user-attachments/assets/ee58068f-8732-4b58-896a-e56d9652d6ee" />
