### PR TITLE
CN-105-ingest-survey-launched-events

### DIFF
--- a/acceptance_tests/features/Exception_manager.feature
+++ b/acceptance_tests/features/Exception_manager.feature
@@ -1,13 +1,13 @@
 Feature: Check exception manager is called for every topic and handles them as expected
 
   # Scenario labelled 1 as we want this one to run at the beginning of the tests as a way of warming up pubsub
-  Scenario: A Bad Json Msg sent to every topic, msg arrives in exception manager
+  Scenario: 1: A Bad Json Msg sent to every topic, msg arrives in exception manager
     When a bad json msg is sent to every topic consumed by RM
     Then each bad msg is seen by exception manager with the message containing "com.fasterxml.jackson.core.JsonParseException"
     And each bad msg can be successfully quarantined
 
   @regression
-  Scenario: Bad EQ launched message turns up in exception manager
+  Scenario: Bad survey launched message turns up in exception manager
     When a bad Survey Launched event is put on the topic
     Then a bad message appears in exception manager with exception message containing "qid '555555' not found!"
     And each bad msg can be successfully quarantined

--- a/acceptance_tests/features/Exception_manager.feature
+++ b/acceptance_tests/features/Exception_manager.feature
@@ -1,7 +1,14 @@
 Feature: Check exception manager is called for every topic and handles them as expected
 
   # Scenario labelled 1 as we want this one to run at the beginning of the tests as a way of warming up pubsub
-  Scenario: 1: A Bad Json Msg sent to every topic, msg arrives in exception manager
+  Scenario: A Bad Json Msg sent to every topic, msg arrives in exception manager
     When a bad json msg is sent to every topic consumed by RM
     Then each bad msg is seen by exception manager with the message containing "com.fasterxml.jackson.core.JsonParseException"
     And each bad msg can be successfully quarantined
+
+  @regression
+  Scenario: Bad EQ launched message turns up in exception manager
+    When a bad Survey Launched event is put on the topic
+    Then a bad message appears in exception manager with exception message containing "qid '555555' not found!"
+    And each bad msg can be successfully quarantined
+

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -50,7 +50,8 @@ def request_replacement_uac_by_sms(context, phone_number, personalisation=None):
             "source": "CC",
             "channel": "CC",
             "correlationId": context.correlation_id,
-            "originatingUser": context.originating_user
+            "originatingUser": context.originating_user,
+            "messageType": "SMS_FULFILMENT"
         },
         "payload": {
             "smsFulfilment": {

--- a/acceptance_tests/features/steps/survey_launched.py
+++ b/acceptance_tests/features/steps/survey_launched.py
@@ -6,7 +6,6 @@ from datetime import datetime, timezone
 from behave import step
 
 from acceptance_tests.utilities.audit_trail_helper import add_random_suffix_to_email
-# from acceptance_tests.utilities.audit_trail_helper import add_random_suffix_to_email
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from config import Config
 

--- a/acceptance_tests/features/steps/survey_launched.py
+++ b/acceptance_tests/features/steps/survey_launched.py
@@ -1,0 +1,52 @@
+import json
+import uuid
+from datetime import datetime, timezone
+
+from behave import step
+
+# from acceptance_tests.utilities.audit_trail_helper import add_random_suffix_to_email
+from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
+from config import Config
+
+
+@step('an SURVEY_LAUNCHED event is received')
+def send_survey_launched(context):
+    context.correlation_id = str(uuid.uuid4())
+    context.originating_user = "test@test.com"
+    message = _send_survey_launched_msg(context.correlation_id, context.originating_user,
+                                        context.emitted_uacs[0]['qid'])
+    context.sent_messages.append(message)
+
+
+# @step('a bad EQ launched event is put on the topic')
+# def bad_eq_put_on_topic(context):
+#     context.originating_user = add_random_suffix_to_email(context.scenario_name)
+#     message = _send_eq_launched_msg(str(uuid.uuid4()), context.originating_user, "555555")
+#     context.message_hashes = [hashlib.sha256(message.encode('utf-8')).hexdigest()]
+#     context.sent_messages.append(message)
+
+
+def _send_survey_launched_msg(correlation_id, originating_user, qid):
+    message = json.dumps(
+        {
+            "header": {
+                "version": Config.EVENT_SCHEMA_VERSION,
+                "topic": Config.PUBSUB_SURVEY_LAUNCHED_TOPIC,
+                "source": "RH",
+                "channel": "RH",
+                "dateTime": f'{datetime.now(timezone.utc).replace(tzinfo=None).isoformat()}Z',
+                "messageId": str(uuid.uuid4()),
+                "correlationId": correlation_id,
+                "originatingUser": originating_user,
+                "messageType": "SURVEY_LAUNCHED",
+            },
+            "payload": {
+                "surveyLaunched": {
+                    "questionnaireId": qid
+                }
+            }
+        }
+    )
+
+    publish_to_pubsub(message, project=Config.PUBSUB_PROJECT, topic=Config.PUBSUB_SURVEY_LAUNCHED_TOPIC)
+    return message

--- a/acceptance_tests/features/steps/survey_launched.py
+++ b/acceptance_tests/features/steps/survey_launched.py
@@ -1,9 +1,11 @@
+import hashlib
 import json
 import uuid
 from datetime import datetime, timezone
 
 from behave import step
 
+from acceptance_tests.utilities.audit_trail_helper import add_random_suffix_to_email
 # from acceptance_tests.utilities.audit_trail_helper import add_random_suffix_to_email
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from config import Config
@@ -18,12 +20,12 @@ def send_survey_launched(context):
     context.sent_messages.append(message)
 
 
-# @step('a bad EQ launched event is put on the topic')
-# def bad_eq_put_on_topic(context):
-#     context.originating_user = add_random_suffix_to_email(context.scenario_name)
-#     message = _send_eq_launched_msg(str(uuid.uuid4()), context.originating_user, "555555")
-#     context.message_hashes = [hashlib.sha256(message.encode('utf-8')).hexdigest()]
-#     context.sent_messages.append(message)
+@step('a bad Survey Launched event is put on the topic')
+def bad_survey_launched_put_on_topic(context):
+    context.originating_user = add_random_suffix_to_email(context.scenario_name)
+    message = _send_survey_launched_msg(str(uuid.uuid4()), context.originating_user, "555555")
+    context.message_hashes = [hashlib.sha256(message.encode('utf-8')).hexdigest()]
+    context.sent_messages.append(message)
 
 
 def _send_survey_launched_msg(correlation_id, originating_user, qid):

--- a/acceptance_tests/features/survey_launched.feature
+++ b/acceptance_tests/features/survey_launched.feature
@@ -1,0 +1,11 @@
+Feature: Survey Launched from RH
+
+  Scenario: Survey launched events are logged and the case flag is updated
+    Given sample file "sample_1_input_england_census_spec.csv" is loaded successfully
+    And an export file template has been created with template "ICL1"
+    When an export file action rule has been created for packcode "ICL1"
+    And UAC_UPDATE message is emitted with active set to true and "eqLaunched" is false
+    When an SURVEY_LAUNCHED event is received
+    Then UAC_UPDATE message is emitted with active set to true and "eqLaunched" is true
+    And a CASE_UPDATE message is emitted where "surveyLaunched" is "True"
+    And the events logged against the case are ["NEW_CASE","EXPORT_FILE","SURVEY_LAUNCHED"]

--- a/acceptance_tests/features/survey_launched.feature
+++ b/acceptance_tests/features/survey_launched.feature
@@ -4,8 +4,8 @@ Feature: Survey Launched from RH
     Given sample file "sample_1_input_england_census_spec.csv" is loaded successfully
     And an export file template has been created with template "ICL1"
     When an export file action rule has been created for packcode "ICL1"
-    And UAC_UPDATE message is emitted with active set to true and "eqLaunched" is false
+    And UAC_UPDATE message is emitted with active set to true and "surveyLaunched" is false
     When an SURVEY_LAUNCHED event is received
-    Then UAC_UPDATE message is emitted with active set to true and "eqLaunched" is true
+    Then UAC_UPDATE message is emitted with active set to true and "surveyLaunched" is true
     And a CASE_UPDATE message is emitted where "surveyLaunched" is "True"
     And the events logged against the case are ["NEW_CASE","EXPORT_FILE","SURVEY_LAUNCHED"]

--- a/acceptance_tests/utilities/audit_trail_helper.py
+++ b/acceptance_tests/utilities/audit_trail_helper.py
@@ -26,6 +26,7 @@ def log_out_user_context_values(context, context_attributes: List[Dict]):
 
     logger.error(context_output)
 
+
 def add_random_suffix_to_email(email_address):
     return f'{email_address}@{get_random_alpha_numerics(4)}'
 

--- a/acceptance_tests/utilities/audit_trail_helper.py
+++ b/acceptance_tests/utilities/audit_trail_helper.py
@@ -26,6 +26,9 @@ def log_out_user_context_values(context, context_attributes: List[Dict]):
 
     logger.error(context_output)
 
+def add_random_suffix_to_email(email_address):
+    return f'{email_address}@{get_random_alpha_numerics(4)}'
+
 
 def build_context_audit_log(context, context_attributes: List[Dict]) -> str:
     context_output = "\n"

--- a/config.py
+++ b/config.py
@@ -15,8 +15,8 @@ class Config:
     PUBSUB_INVALID_CASE_TOPIC = os.getenv('PUBSUB_INVALID_CASE_TOPIC',
                                           'event_invalid-case')
     PUBSUB_PRINT_FULFILMENT_TOPIC = os.getenv('PUBSUB_PRINT_FULFILMENT_TOPIC', 'event_print-fulfilment')
-    PUBSUB_EQ_LAUNCH_TOPIC = os.getenv('PUBSUB_EQ_LAUNCH_TOPIC',  # noqa: F841
-                                       'event_eq-launch')  # noqa: F841
+    PUBSUB_SURVEY_LAUNCHED_TOPIC = os.getenv('PUBSUB_SURVEY_LAUNCHED_TOPIC',  # noqa: F841
+                                             'event_survey-launched')  # noqa: F841
     PUBSUB_DEACTIVATE_UAC_TOPIC = os.getenv('PUBSUB_DEACTIVATE_UAC_TOPIC', 'event_deactivate-uac')
     PUBSUB_OUTBOUND_UAC_SUBSCRIPTION = os.getenv('PUBSUB_OUTBOUND_UAC_SUBSCRIPTION', 'event_uac-update_rh_at')
     PUBSUB_OUTBOUND_CASE_SUBSCRIPTION = os.getenv('PUBSUB_OUTBOUND_CASE_SUBSCRIPTION', 'event_case-update_rh_at')


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](github.com/ONSdigital/census-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date
To follow the Census event structure, we need to replace EQ_LAUNCH with SURVEY_LAUNCHED. This means updating the events where it's used and updating pubsub topic/subscriptions. I've added a new test to cover the scenario as well

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added SURVEY_LAUNCHED test

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run with other branches on the card and the tests should pass
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://officefornationalstatistics.atlassian.net/browse/CN-105)
