### PR TITLE
CN-126 Use generated test keys

### DIFF
--- a/.run/Template Python.run.xml
+++ b/.run/Template Python.run.xml
@@ -1,21 +1,29 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="true" type="PyBehaveRunConfigurationType" factoryName="Behave">
+  <configuration default="true" type="PythonConfigurationType" factoryName="Python">
     <module name="census31-rm-acceptance-tests" />
     <option name="ENV_FILES" value="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
-      <env name="PUBSUB_EMULATOR_HOST" value="localhost:8538" />
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name=" PUBSUB_EMULATOR_HOST" value="localhost:8538" />
     </envs>
     <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Pipenv (census31-rm-acceptance-tests)" />
     <option name="WORKING_DIRECTORY" value="" />
-    <option name="IS_MODULE_SDK" value="true" />
+    <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <option name="DEBUG_JUST_MY_CODE" value="false" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="RUN_TOOL" value="" />
-    <option name="ADDITIONAL_ARGS" value="" />
+    <option name="SCRIPT_NAME" value="" />
+    <option name="PARAMETERS" value="" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
     <method v="2" />
   </configuration>
 </component>

--- a/README.md
+++ b/README.md
@@ -118,3 +118,11 @@ such a long wait for messages.
 ### Exception test naming
 All feature files have been named with all lower case titles. The one exception is the `Exception_manager.feature` test file. This is because we want this test to run at the beginning of the test run, and behave will execure feature files that are capitalised before files named with lower case titles.
 The reason we want this test to run first is to help warmup a cold pubsub in the CI environment. This test uses all the pubsub topics and services. It also utilises some waits, so it should work as a good test to run to ensure pubsub is fully warmed up when the rest of the tests run.
+
+### Test Keys
+
+For development environments, the services is configured to use the dummy test keys
+from [census31-rm-docker-dev](https://github.com/ONSdigital/census31-rm-docker-dev) by default, assuming the repository
+is in the same parent directory.
+
+See [census31-rm-docker-dev Test keys](https://github.com/ONSdigital/census31-rm-docker-dev#test-keys) for details.

--- a/config.py
+++ b/config.py
@@ -74,7 +74,7 @@ class Config:
                                                'dummy-key-census-rm-test-private.asc'))
     )
     OUR_EXPORT_FILE_DECRYPTION_KEY_PASSPHRASE = os.getenv('OUR_EXPORT_FILE_DECRYPTION_KEY_PASSPHRASE',
-                                                          'dummy-census-rm-test')
+                                                          'test')
 
     API_USER_EMAIL = os.getenv('API_USER_EMAIL', 'dummy@fake-email.com')
 

--- a/config.py
+++ b/config.py
@@ -60,9 +60,8 @@ class Config:
     NOTIFY_STUB_SERVICE = f'http://{NOTIFY_STUB_HOST}:{NOTIFY_STUB_PORT}'
 
     EXPORT_FILE_DESTINATION_CONFIG_JSON_PATH = Path(
-        os.getenv('EXPORT_FILE_DESTINATION_CONFIG_JSON_PATH') or Path(__file__).parents[1].joinpath(
-            'census31-rm-docker-dev',
-            'dummy_destination_config.json'))
+        os.getenv('EXPORT_FILE_DESTINATION_CONFIG_JSON_PATH') or Path(__file__).parent.joinpath(
+            'dummy_export_file_destination_config.json'))
     EXPORT_FILE_DESTINATIONS_CONFIG = json.loads(
         EXPORT_FILE_DESTINATION_CONFIG_JSON_PATH.read_text()) \
         if EXPORT_FILE_DESTINATION_CONFIG_JSON_PATH and EXPORT_FILE_DESTINATION_CONFIG_JSON_PATH.exists() else None

--- a/config.py
+++ b/config.py
@@ -60,8 +60,9 @@ class Config:
     NOTIFY_STUB_SERVICE = f'http://{NOTIFY_STUB_HOST}:{NOTIFY_STUB_PORT}'
 
     EXPORT_FILE_DESTINATION_CONFIG_JSON_PATH = Path(
-        os.getenv('EXPORT_FILE_DESTINATION_CONFIG_JSON_PATH') or Path(__file__).parent.joinpath(
-            'dummy_export_file_destination_config.json'))
+        os.getenv('EXPORT_FILE_DESTINATION_CONFIG_JSON_PATH') or Path(__file__).parents[1].joinpath(
+            'census31-rm-docker-dev',
+            'dummy_destination_config.json'))
     EXPORT_FILE_DESTINATIONS_CONFIG = json.loads(
         EXPORT_FILE_DESTINATION_CONFIG_JSON_PATH.read_text()) \
         if EXPORT_FILE_DESTINATION_CONFIG_JSON_PATH and EXPORT_FILE_DESTINATION_CONFIG_JSON_PATH.exists() else None
@@ -69,10 +70,11 @@ class Config:
     FILE_UPLOAD_MODE = os.getenv('FILE_UPLOAD_MODE', 'LOCAL')
     OUR_EXPORT_FILE_DECRYPTION_KEY = os.getenv(
         'OUR_EXPORT_FILE_DECRYPTION_KEY',
-        str(RESOURCE_FILE_PATH.joinpath('dummy_keys',
-                                        'dummy-key-census-rm-private.asc'))
+        str(Path(__file__).parents[1].joinpath('census31-rm-docker-dev', 'dummy_keys',
+                                               'dummy-key-census-rm-test-private.asc'))
     )
-    OUR_EXPORT_FILE_DECRYPTION_KEY_PASSPHRASE = os.getenv('OUR_EXPORT_FILE_DECRYPTION_KEY_PASSPHRASE', 'test')
+    OUR_EXPORT_FILE_DECRYPTION_KEY_PASSPHRASE = os.getenv('OUR_EXPORT_FILE_DECRYPTION_KEY_PASSPHRASE',
+                                                          'dummy-census-rm-test')
 
     API_USER_EMAIL = os.getenv('API_USER_EMAIL', 'dummy@fake-email.com')
 

--- a/dummy_export_file_destination_config.json
+++ b/dummy_export_file_destination_config.json
@@ -1,10 +1,10 @@
 {
   "test_supplier": {
     "exportDirectory": "test_supplier/print_services",
-    "encryptionKeyFilename": "dummy-key-supplier-a-public.asc"
+    "encryptionKeyFilename": "dummy-key-test-supplier-a-public.asc"
   },
   "internal_reprographics": {
     "exportDirectory": "internal_reprographics/print_services",
-    "encryptionKeyFilename": "dummy-key-supplier-b-public.asc"
+    "encryptionKeyFilename": "dummy-key-test-supplier-b-public.asc"
   }
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](github.com/ONSdigital/census-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

We want to move to generating keys for tests locally rather than storing test credentials in the repository.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Remove dummy keys
- Configure the ATs to use the generated keys in census31-rm-docker-dev by default

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Follow the instructions in https://github.com/ONSdigital/census31-rm-docker-dev/pull/19 to run the ATs on branch.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://officefornationalstatistics.atlassian.net/browse/CN-126